### PR TITLE
Adding underscore to variable regex

### DIFF
--- a/syntaxes/jq.tmLanguage.json
+++ b/syntaxes/jq.tmLanguage.json
@@ -84,7 +84,7 @@
 				}
 			}, {
 				"name": "variable",
-				"match": "\\$[a-zA-Z][a-zA-Z0-9]*"
+				"match": "\\$[a-zA-Z_][a-zA-Z0-9_]*"
 			}, {
 				"name": "property",
 				"match": "[a-zA-Z][a-zA-Z0-9]*\\b(?!:)"


### PR DESCRIPTION
Variables are allowed to have an underscore in them and currently the syntax highlighting just stops