### PR TITLE
Use jq syntax from atom jq support

### DIFF
--- a/samples/sample.jq
+++ b/samples/sample.jq
@@ -38,3 +38,16 @@ def csv2jsonHelper:
     ([]; . + [ $row|objectify($headers) ]);
 
 csv2jsonHelper
+
+def test_interpolate: "abc \("nested \(. | ascii_upcase)")";
+
+def nothing: empty;
+
+def as_obj_var: . as {$a, $b} | $a;
+def as_array_var: [1] as [$a] | $a;
+def as_obj_array_var: {a: [1]} as {a: [$a, $b], $c} | $a;
+def as_array_obj_var: [{a: 1}] as [{$a, a: $b}] | $a;
+
+def array_in_object: {abc: [123, "abc", {abc: [123, 123]}]};
+
+def f($var): $var;

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -1,0 +1,3 @@
+This syntax grammar is CSON syntax grammar from https://github.com/wader/language-jq/pull/5 converted to JSON.
+Which in turn was based on https://github.com/fadado/JBOL/blob/master/doc/JQ-language-grammar.md.
+Both are under MIT license.

--- a/syntaxes/jq.tmLanguage.json
+++ b/syntaxes/jq.tmLanguage.json
@@ -1,101 +1,330 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "jq",
-	"patterns": [
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#punctuation"
-		},
-		{
-			"include": "#literals"
-		},
-		{
-			"include": "#strings"
-		},
-		{
-			"include": "#identifiers"
-		}
-	],
-	"repository": {
-		"comments": {
-			"patterns": [{
-				"name": "comment",
-				"match": "#.*$"
-			}]
-		},
-		"keywords": {
-			"patterns": [{
-				"name": "keyword",
-				"match": "(?<!\\.|\\$)\\b(and|as|empty|not|or|reduce)\\b(?!\\.)"
-			}, {
-				"name": "keyword.control",
-				"match": "(?<!\\.|\\$)\\b(break|catch|elif|else|end|if|label|then|try)\\b(?!\\.)"
-			}, {
-				"name": "constant.language",
-				"match": "(?<!\\.|\\$)\\b(false|null|true)\\b(?!\\.)"
-			}]
-		},
-		"punctuation": {
-			"patterns": [{
-				"name": "punctuation.pipe.jq",
-				"match": "\\|"
-			}, {
-				"name": "punctuation",
-				"match": "!=|%|\\*|\\(|\\)|-|==|=|\\+|\\[|\\{|\\]|\\}|:|;|,|<=|<|\\.\\.|\\.|>=|>|//|/|\\?"
-			}]
-		},
-		"strings": {
-			"name": "string.quoted.double",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape",
-					"match": "\\\\."
-				}
-			]
-		},
-		"literals": {
-			"patterns": [{
-				"name": "constant.numeric",
-				"match": "\\b\\d+(\\.\\d+)?"
-			}]
-		},
-		"identifiers": {
-			"patterns": [{
-				"name": "variable.language",
-				"match": "(?<!\\.|\\$)\\b(bbb)\\b(?!\\.)"
-			}, {
-				"match": "\\b(def)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-				"captures": {
-					"1": { "name": "keyword.def" },
-					"2": { "name": "entity.name.function" }
-				}
-			}, {
-				"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(\\()",
-				"captures": {
-					"1": { "name": "meta.function-call" },
-					"2": { "name": "punctuation" }
-				}
-			}, {
-				"name": "variable",
-				"match": "\\$[a-zA-Z_][a-zA-Z0-9_]*"
-			}, {
-				"name": "property",
-				"match": "[a-zA-Z][a-zA-Z0-9]*\\b(?!:)"
-			}, {
-				"match": "([a-zA-Z][a-zA-Z0-9]*)\\b(:)",
-				"captures": {
-					"1": { "name": "meta.object-literal.key" },
-					"2": { "name": "punctuation" }
-				}
-			}]
-		}
-	},
-	"scopeName": "source.jq"
+  "name": "jq",
+  "scopeName": "source.jq",
+  "fileTypes": [
+    "jq"
+  ],
+  "patterns": [
+    {
+      "include": "#main"
+    }
+  ],
+  "repository": {
+    "main": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#array"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#function"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#field"
+        },
+        {
+          "include": "#variable"
+        },
+        {
+          "include": "#format"
+        },
+        {
+          "include": "#constant"
+        },
+        {
+          "include": "#keyword"
+        },
+        {
+          "include": "#filter"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#operator"
+        },
+        {
+          "include": "#punctuation"
+        }
+      ]
+    },
+    "comment": {
+      "name": "comment.line.number-sign.jq",
+      "begin": "#",
+      "end": "$"
+    },
+    "constant": {
+      "name": "constant.language.jq",
+      "match": "(?<!\\.)\\b(true|false|null)(?!\\s*:)\\b"
+    },
+    "field": {
+      "name": "entity.other.attribute-name.jq",
+      "match": "\\.[a-zA-Z_]\\w*"
+    },
+    "filter": {
+      "name": "support.function.jq",
+      "match": "([a-zA-Z_]\\w*::)*[a-zA-Z_]\\w*"
+    },
+    "format": {
+      "name": "constant.other.symbol.jq",
+      "match": "@\\w+"
+    },
+    "function": {
+      "name": "meta.function.jq",
+      "begin": "(?<!\\.)\\bdef(?!\\s*:)\\b",
+      "end": "([a-zA-Z_]\\w*::)*[a-zA-Z_]\\w*",
+      "beginCaptures": {
+        "0": {
+          "name": "storage.type.function.jq"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "entity.name.function.jq"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "name": "invalid.illegal.identifier.jq",
+          "match": "\\S+"
+        }
+      ]
+    },
+    "keyword": {
+      "name": "keyword.control.jq",
+      "match": "(?x)\n(?<!\\.) \\b\n( and\n| as\n| break\n| catch\n| elif\n| else\n| empty\n| end\n| foreach\n| if\n| import\n| include\n| label\n| module\n| or\n| reduce\n| then\n| try\n) (?!\\s*:) \\b"
+    },
+    "number": {
+      "name": "constant.numeric.jq",
+      "match": "([0-9.]{2,}|[0-9]+)([eE][+-]?[0-9]+)?"
+    },
+    "array": {
+      "name": "meta.array.jq",
+      "begin": "\\[",
+      "end": "\\]",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.bracket.square.begin.jq"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.bracket.square.end.jq"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.bracket.round.begin.jq"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.bracket.round.end.jq"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#self_in_round_brackets"
+            }
+          ]
+        },
+        {
+          "include": "#main"
+        },
+        {
+          "name": "punctuation.separator.jq",
+          "match": ","
+        },
+        {
+          "name": "invalid.illegal.identifier.jq",
+          "match": "\\S+"
+        }
+      ]
+    },
+    "object": {
+      "name": "meta.object.jq",
+      "begin": "{",
+      "end": "}",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.bracket.curly.begin.jq"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.bracket.curly.end.jq"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#variable"
+        },
+        {
+          "name": "entity.other.attribute-name.id.jq",
+          "match": "([a-zA-Z_]\\w*::)*[a-zA-Z_]\\w*"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.bracket.round.begin.jq"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.bracket.round.end.jq"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#self_in_round_brackets"
+            }
+          ]
+        },
+        {
+          "begin": ":",
+          "end": ",|(?=})",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.separator.begin.jq"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.separator.end.jq"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#main"
+            }
+          ]
+        },
+        {
+          "name": "punctuation.separator.jq",
+          "match": ","
+        },
+        {
+          "name": "invalid.illegal.identifier.jq",
+          "match": "\\S+"
+        }
+      ]
+    },
+    "operator": {
+      "name": "keyword.operator.jq",
+      "match": "(?x) ( \\.\\.? | \\?// | \\? | ==? | //=? | \\|=? | \\+=? | -=? | \\*=? | /=? | %=? | != | <=? | >=? )"
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "name": "punctuation.bracket.round.jq",
+          "match": "\\(|\\)"
+        },
+        {
+          "name": "punctuation.bracket.square.jq",
+          "match": "\\[|\\]"
+        },
+        {
+          "name": "punctuation.separator.jq",
+          "match": ",|;|:"
+        }
+      ]
+    },
+    "self_in_round_brackets": {
+      "patterns": [
+        {
+          "begin": "\\(",
+          "end": "\\)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.bracket.round.begin.jq"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.bracket.round.end.jq"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#main"
+            }
+          ]
+        },
+        {
+          "include": "#main"
+        }
+      ]
+    },
+    "string": {
+      "name": "string.quoted.double.jq",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.jq",
+          "match": "\\\\([\"\\\\/bfnrt]|u[0-9a-fA-F]{4})"
+        },
+        {
+          "include": "#string_interpolation"
+        },
+        {
+          "name": "invalid.illegal.unrecognized-string-escape.jq",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "string_interpolation": {
+      "name": "source.jq.embedded.source",
+      "begin": "\\\\\\(",
+      "end": "\\)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.jq.begin.jq"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.jq.end.jq"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#self_in_round_brackets"
+        }
+      ]
+    },
+    "variable": {
+      "name": "variable.other.jq",
+      "match": "\\$([a-zA-Z_]\\w*::)*[a-zA-Z_]\\w*"
+    }
+  }
 }


### PR DESCRIPTION
Difference to current syntax:
Supports string interpolation highlighting
Add foreach keyword
def name and function highlighting the same

Additional to atom syntax:
Better array/pattern support
Add //? operator

Was convert using:
cson2json < language-jq/grammars/jq.cson > jq.tmLanguage.json

Related PR to update CSON grammar wader/language-jq#5
