### PR TITLE
Fix string interpolation hiliting

### DIFF
--- a/syntaxes/jq.tmLanguage.json
+++ b/syntaxes/jq.tmLanguage.json
@@ -42,6 +42,25 @@
 		},
 		"punctuation": {
 			"patterns": [{
+				"begin": "\\(",
+				"beginCaptures": {
+					"0": {
+						"name": "punctuation"
+					}
+				},
+				"end": "\\)",
+				"endCaptures": {
+					"0": {
+						"name": "punctuation"
+					}
+				},
+				"contentName": "meta.embedded.source.jq",
+				"patterns": [
+					{
+						"include": "$self"
+					}
+				]
+			}, {
 				"name": "punctuation.pipe.jq",
 				"match": "\\|"
 			}, {
@@ -55,6 +74,25 @@
 			"end": "\"",
 			"patterns": [
 				{
+					"begin": "\\\\\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation"
+						}
+					},
+					"contentName": "meta.embedded.source.jq",
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				}, {
 					"name": "constant.character.escape",
 					"match": "\\\\."
 				}
@@ -77,10 +115,9 @@
 					"2": { "name": "entity.name.function" }
 				}
 			}, {
-				"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(\\()",
+				"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\()",
 				"captures": {
-					"1": { "name": "meta.function-call" },
-					"2": { "name": "punctuation" }
+					"1": { "name": "meta.function-call" }
 				}
 			}, {
 				"name": "variable",


### PR DESCRIPTION
Strings can contain arbitrary jq code, embedded between \( and ).

To fix this, we need to match the \(...) under strings.

In addition, because the arbitrary jq code could contain balanced
parentheses, we need to match those under punctuation.

Finally, since the code could also contain function calls, don't
include the opening '(' when matching a function call, so that
the parameters are handled by the newly added balanced parenthesis
code.